### PR TITLE
Fix : 프로젝트 삭제시 해당 프로젝트 내 이미지 파일들도 함께 삭제 될 수 있도록 수정

### DIFF
--- a/server/DSMP/src/main/java/com/knuipalab/dsmp/controller/StorageController.java
+++ b/server/DSMP/src/main/java/com/knuipalab/dsmp/controller/StorageController.java
@@ -1,13 +1,10 @@
 package com.knuipalab.dsmp.controller;
 
-import com.knuipalab.dsmp.httpResponse.BasicResponse;
 import org.springframework.core.io.Resource;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 
 public interface StorageController {

--- a/server/DSMP/src/main/java/com/knuipalab/dsmp/controller/project/api/ProjectApiController.java
+++ b/server/DSMP/src/main/java/com/knuipalab/dsmp/controller/project/api/ProjectApiController.java
@@ -1,21 +1,25 @@
 package com.knuipalab.dsmp.controller.project.api;
 
-import com.knuipalab.dsmp.dto.project.*;
+import com.knuipalab.dsmp.dto.project.ProjectInviteRequestDto;
+import com.knuipalab.dsmp.dto.project.ProjectOustRequestDto;
+import com.knuipalab.dsmp.dto.project.ProjectRequestDto;
+import com.knuipalab.dsmp.dto.project.ProjectResponseDto;
 import com.knuipalab.dsmp.httpResponse.BasicResponse;
 import com.knuipalab.dsmp.httpResponse.success.SuccessDataResponse;
 import com.knuipalab.dsmp.httpResponse.success.SuccessResponse;
 import com.knuipalab.dsmp.service.project.ProjectService;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@RequiredArgsConstructor
 @RestController
 public class ProjectApiController {
 
-    @Autowired
-    ProjectService projectService;
+
+    private final ProjectService projectService;
 
     // DB에 존재하는 모든 프로젝트 종류를 반환
     @GetMapping("api/Project")
@@ -51,7 +55,7 @@ public class ProjectApiController {
         return ResponseEntity.ok().body(new SuccessResponse());
     }
 
-    // projectId를 기반으로 Project 삭제 -> 관련 metadata들을 cascade하게 삭제
+    // projectId를 기반으로 Project 삭제 -> 관련 metadata들, 이미지 파일들을 cascade하게 삭제
     @DeleteMapping("api/Project/{projectId}")
     public ResponseEntity<? extends  BasicResponse> delete(@PathVariable String projectId){
         projectService.deleteById(projectId);

--- a/server/DSMP/src/main/java/com/knuipalab/dsmp/service/project/ProjectService.java
+++ b/server/DSMP/src/main/java/com/knuipalab/dsmp/service/project/ProjectService.java
@@ -5,16 +5,20 @@ import com.knuipalab.dsmp.domain.project.Project;
 import com.knuipalab.dsmp.domain.project.ProjectRepository;
 import com.knuipalab.dsmp.domain.user.User;
 import com.knuipalab.dsmp.domain.user.UserRepository;
-import com.knuipalab.dsmp.dto.project.*;
+import com.knuipalab.dsmp.dto.project.ProjectInviteRequestDto;
+import com.knuipalab.dsmp.dto.project.ProjectOustRequestDto;
+import com.knuipalab.dsmp.dto.project.ProjectRequestDto;
+import com.knuipalab.dsmp.dto.project.ProjectResponseDto;
 import com.knuipalab.dsmp.httpResponse.error.ErrorCode;
 import com.knuipalab.dsmp.httpResponse.error.handler.exception.ProjectNotFoundException;
 import com.knuipalab.dsmp.httpResponse.error.handler.exception.UnAuthorizedAccessException;
 import com.knuipalab.dsmp.httpResponse.error.handler.exception.UserEmailBadRequestException;
 import com.knuipalab.dsmp.httpResponse.error.handler.exception.UserNotFoundException;
 import com.knuipalab.dsmp.service.metadata.MetaDataService;
+import com.knuipalab.dsmp.service.storage.StorageService;
 import com.knuipalab.dsmp.service.user.UserService;
+import lombok.RequiredArgsConstructor;
 import org.bson.types.ObjectId;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,23 +28,21 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+@RequiredArgsConstructor
 @Service
 public class ProjectService {
 
-    @Autowired
-    private HttpSession httpSession;
+    private final HttpSession httpSession;
 
-    @Autowired
-    private ProjectRepository projectRepository;
+    private final ProjectRepository projectRepository;
 
-    @Autowired
-    private MetaDataService metaDataService;
+    private final MetaDataService metaDataService;
 
-    @Autowired
-    private UserService userService;
+    private final UserService userService;
 
-    @Autowired
-    private UserRepository userRepository;
+    private final UserRepository userRepository;
+
+    private final StorageService storageService;
 
 
     @Transactional (readOnly = true)
@@ -122,6 +124,8 @@ public class ProjectService {
         }
 
         metaDataService.deleteAllByProjectId(projectId);
+
+        storageService.deleteAll(projectId);
 
         projectRepository.delete(project);
     }

--- a/server/DSMP/src/main/java/com/knuipalab/dsmp/service/storage/FileSystemStorageService.java
+++ b/server/DSMP/src/main/java/com/knuipalab/dsmp/service/storage/FileSystemStorageService.java
@@ -83,7 +83,7 @@ public class FileSystemStorageService implements StorageService {
 
         Path projectPath = this.rootLocation.resolve(Paths.get(projectId)).normalize().toAbsolutePath();
         try {
-            FileSystemUtils.deleteRecursively(projectPath);
+            FileSystemUtils.deleteRecursively(projectPath); // 현재 디렉토리 및 자식 파일 삭제
         } catch (IOException e) {
             e.printStackTrace();
             throw new FileIOException(ErrorCode.FILE_IO_EXCEPTION);


### PR DESCRIPTION
issue : #253

기존의 프로젝트 삭제시 해당 프로젝트 내 이미지 파일들이 여전히 잔류해 있는 에러가 있었다.
따라서 프로젝트 삭제 api 호출시, projectService 영역에서 함께 처리 될 수 있도록 수정해 하였다.