### PR TITLE
Feat : MetaData Read를 Paging을 통해 최적화

### DIFF
--- a/server/DSMP/src/main/java/com/knuipalab/dsmp/metadata/CustomizedMetaDataRepository.java
+++ b/server/DSMP/src/main/java/com/knuipalab/dsmp/metadata/CustomizedMetaDataRepository.java
@@ -5,4 +5,5 @@ import java.util.HashMap;
 public interface CustomizedMetaDataRepository {
     void updateType(String metadataId, String type);
     void setMalignancyClassification(String metadataId, HashMap classificationSet);
+    void findByProjectIdWithPagingAndFiltering(String projectId,int page,int size);
 }

--- a/server/DSMP/src/main/java/com/knuipalab/dsmp/metadata/CustomizedMetaDataRepositoryImpl.java
+++ b/server/DSMP/src/main/java/com/knuipalab/dsmp/metadata/CustomizedMetaDataRepositoryImpl.java
@@ -1,12 +1,19 @@
 package com.knuipalab.dsmp.metadata;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.util.Assert;
 
+
 import java.util.HashMap;
+import java.util.List;
 
 public class CustomizedMetaDataRepositoryImpl implements CustomizedMetaDataRepository{
 
@@ -35,4 +42,29 @@ public class CustomizedMetaDataRepositoryImpl implements CustomizedMetaDataRepos
         });
         mongoTemplate.updateFirst(query,update,"metadata");
     }
+
+    @Override
+    public void findByProjectIdWithPagingAndFiltering(String projectId, int page, int size) {
+
+        Pageable pageable = PageRequest.of(page,size, Sort.unsorted());
+
+        Query query = new Query()
+                .with(pageable)
+                .skip(pageable.getPageSize() * pageable.getPageNumber()) // offset
+                .limit(pageable.getPageSize());
+
+        //Add Filtered
+        query.addCriteria(Criteria.where("projectId").is(projectId));
+
+        List<MetaData> filteredMetaData = mongoTemplate.find(query, MetaData.class, "metadata");
+        Page<MetaData> metaDataPage = PageableExecutionUtils.getPage(
+                filteredMetaData,
+                pageable,
+                () -> mongoTemplate.count(query.skip(-1).limit(-1),MetaData.class)
+                // query.skip(-1).limit(-1)의 이유는 현재 쿼리가 페이징 하려고 하는 offset 까지만 보기에 이를 맨 처음부터 끝까지러 set 해줘 정확한 도큐먼트 개수를 구한다.
+        );
+
+    }
+
+
 }

--- a/server/DSMP/src/test/java/com/knuipalab/dsmp/QA/metadata/MetaDataQA.java
+++ b/server/DSMP/src/test/java/com/knuipalab/dsmp/QA/metadata/MetaDataQA.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.javafaker.Faker;
 import com.google.common.collect.Lists;
+import com.knuipalab.dsmp.metadata.CustomizedMetaDataRepository;
 import com.knuipalab.dsmp.metadata.MetaData;
 import com.knuipalab.dsmp.metadata.MetaDataRepository;
 import com.knuipalab.dsmp.project.Project;
@@ -35,6 +36,9 @@ public class MetaDataQA {
 
     @SpyBean
     MetaDataRepository metaDataRepository;
+
+    @SpyBean
+    CustomizedMetaDataRepository customizedMetaDataRepository;
 
     Logger log = (Logger) LoggerFactory.getLogger(MetaDataQA.class);
 
@@ -75,7 +79,7 @@ public class MetaDataQA {
 
         long beforeTime = System.currentTimeMillis();
 
-        long METADATA_SIZE = 1000;
+        long METADATA_SIZE = 100;
 
         Faker faker = new Faker();
         StringBuilder strBodyList = new StringBuilder();
@@ -188,8 +192,14 @@ public class MetaDataQA {
 
         long afterTime = System.currentTimeMillis(); // 코드 실행 후에 시간 받아오기
         long secDiffTime = (afterTime - beforeTime); //두 시간에 차 계산
-
+        log.info("findAll 개수 : "+metaDataList.size());
         log.info("findAll QA 실행 시간(m) : "+secDiffTime);
+    }
+
+    @Profile("QA")
+    @Test
+    public void findByProjectIdWithPagingAndFiltering() {
+        customizedMetaDataRepository.findByProjectIdWithPagingAndFiltering("54321",0,10);
     }
 
 


### PR DESCRIPTION

issue : #272

기능 추가 :

CustomizedMetaDataRepository 내 findByProjectIdWithPagingAndFiltering API를 추가하여, 파라미터 값으로 받은 page, size, projectId 를 통해 해당 프로젝트 아이디를 가진 메타데이터 중 page 값에 해당 하는 메타데이터들을 size 만큼 받아 온다.

MeataData QA로 실제 DB로 접근하여 테스팅시,

* 기존 방식으로 10만개 기준 2sec 380ms가 소요되지만 size를 20으로 규정 후 paging 기법으로 찾으니, 330ms만에 해당 페이징 내에 있는 메타데이터 리스트를 찾아올 수 있었다.

추가 방향 :

1. 필터링 값들을 동적으로 적용할 수 있도록 수정한다.
2. 개선율을 100만개 단위로 계산해 보고, 성능향상을 기록한다.